### PR TITLE
fix(http_transport): ClientAsync throws exception when optional parameters are not set.

### DIFF
--- a/examples/fast_api_example.py
+++ b/examples/fast_api_example.py
@@ -1,5 +1,6 @@
 from fastapi import FastAPI
 from sinch import ClientAsync
+from sinch import Client
 
 """
 Run with: uvicorn fast_api_example:app --reload
@@ -8,16 +9,16 @@ Run with: uvicorn fast_api_example:app --reload
 app = FastAPI()
 
 sinch_client = ClientAsync(
-    key_id="Spodek",
-    key_secret="wKatowicach"
+    key_id="KEY_ID",
+    key_secret="KEY_SECRET",
+    project_id="PROJECT_ID"
 )
 
 
 @app.get("/available_numbers")
 async def project():
-    numbers = await sinch_client.numbers.list_available_numbers(
+    numbers = await sinch_client.numbers.available.list(
         region_code="US",
         number_type="LOCAL",
-        project_id="e15b2651-daac-4ccb-92e8-e3066d1d033b"
     )
     return {"available_numbers": numbers.available_numbers}

--- a/sinch/core/ports/http_transport.py
+++ b/sinch/core/ports/http_transport.py
@@ -31,7 +31,10 @@ class HTTPTransport(ABC):
 
     def prepare_request(self, endpoint: HTTPEndpoint) -> HttpRequest:
         protocol = "http://" if self.sinch.configuration.disable_https else "https://"
+
         url_query_params = endpoint.build_query_params()
+        if url_query_params is not None:
+            url_query_params = {key: value for key, value in url_query_params.items() if value is not None}
 
         return HttpRequest(
             headers={},


### PR DESCRIPTION
Hi,

I was testing Sinch service and tried to use the fast_api example but it seems that it is outdated.
I also faced an issue with ClientAsync, aiohttp does not accept query params with None values, I made a quick fix that you can find in this PR. (I'm not a Pythonist, so you may have a better fix).
Cheers,

```
Traceback (most recent call last):
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/uvicorn/protocols/http/h11_impl.py", line 428, in run_asgi
    result = await app(  # type: ignore[func-returns-value]
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/uvicorn/middleware/proxy_headers.py", line 78, in __call__
    return await self.app(scope, receive, send)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/fastapi/applications.py", line 276, in __call__
    await super().__call__(scope, receive, send)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/applications.py", line 122, in __call__
    await self.middleware_stack(scope, receive, send)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 184, in __call__
    raise exc
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/middleware/errors.py", line 162, in __call__
    await self.app(scope, receive, _send)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 79, in __call__
    raise exc
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/middleware/exceptions.py", line 68, in __call__
    await self.app(scope, receive, sender)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 21, in __call__
    raise e
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/fastapi/middleware/asyncexitstack.py", line 18, in __call__
    await self.app(scope, receive, send)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/routing.py", line 718, in __call__
    await route.handle(scope, receive, send)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/routing.py", line 276, in handle
    await self.app(scope, receive, send)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/starlette/routing.py", line 66, in app
    response = await func(request)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/fastapi/routing.py", line 237, in app
    raw_response = await run_endpoint_function(
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/fastapi/routing.py", line 163, in run_endpoint_function
    return await dependant.call(**values)
  File "/home/workstation/projects/sinch-sdk-python/examples/fast_api_example.py", line 25, in project
    numbers = await sinch_client.numbers.available.list(
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/sinch/core/adapters/asyncio_http_adapter.py", line 19, in request
    async with session.request(
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/aiohttp/client.py", line 1141, in __aenter__
    self._resp = await self._coro
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/aiohttp/client.py", line 508, in _request
    req = self._request_class(
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/aiohttp/client_reqrep.py", line 283, in __init__
    url2 = url.with_query(params)
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/yarl/_url.py", line 1007, in with_query
    new_query = self._get_str_query(*args, **kwargs) or ""
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/yarl/_url.py", line 968, in _get_str_query
    query = "&".join(self._query_seq_pairs(quoter, query.items()))
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/yarl/_url.py", line 931, in _query_seq_pairs
    yield quoter(key) + "=" + quoter(cls._query_var(val))
  File "/home/workstation/projects/sinch-sdk-python/venv/lib/python3.10/site-packages/yarl/_url.py", line 946, in _query_var
    raise TypeError(
TypeError: Invalid variable type: value should be str, int or float, got None of type <class 'NoneType'>
```