### PR TITLE
DEVEXP-696: Disable E2E tests

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -51,7 +51,3 @@ jobs:
     - name: Lint with flake8
       run: |
         flake8 sinch --count --max-complexity=10 --max-line-length=120 --statistics
-
-    - name: Test coverage report
-      run: |
-        python -m coverage report

--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -52,25 +52,6 @@ jobs:
       run: |
         flake8 sinch --count --max-complexity=10 --max-line-length=120 --statistics
 
-    - name: Checkout Wiremock fixtures repo
-      uses: actions/checkout@v3
-      with:
-        repository: sinch/sinch-sdk-internal-specs
-        token: ${{ secrets.GH_PAT }}
-        ref: numbers_fixtures
-        path: sinch-sdk-internal-specs
-
-    - uses: actions/setup-node@v3
-    - name: Install wait-port
-      run: |
-        sudo npm install -g wait-port
-
-    - name: Test E2E with Pytest and Wiremock
-      run: |
-        cd sinch-sdk-internal-specs/fixtures/python/ && java -jar wiremock-studio-2.32.0-17.jar &
-        wait-port localhost:8000
-        coverage run --source=. -m pytest
-
     - name: Test coverage report
       run: |
         python -m coverage report


### PR DESCRIPTION
As the e2e tests are not passing anymore due to a github user issue, let's disable them (as well as the coverage report) as they need to be replaced with the official solution anyway.