### PR TITLE
chore: rename Numbers class

### DIFF
--- a/sinch/core/clients/sinch_client_sync.py
+++ b/sinch/core/clients/sinch_client_sync.py
@@ -3,7 +3,7 @@ from sinch.core.clients.sinch_client_configuration import Configuration
 from sinch.core.token_manager import TokenManager
 from sinch.core.adapters.requests_http_transport import HTTPTransportRequests
 from sinch.domains.authentication import Authentication
-from sinch.domains.numbers import Numbers
+from sinch.domains.numbers import VirtualNumbers
 from sinch.domains.conversation import Conversation
 from sinch.domains.sms import SMS
 from sinch.domains.verification import Verification
@@ -43,7 +43,7 @@ class SinchClient:
         )
 
         self.authentication = Authentication(self)
-        self.numbers = Numbers(self)
+        self.numbers = VirtualNumbers(self)
         self.conversation = Conversation(self)
         self.sms = SMS(self)
         self.verification = Verification(self)

--- a/sinch/domains/numbers/__init__.py
+++ b/sinch/domains/numbers/__init__.py
@@ -1,3 +1,3 @@
-from sinch.domains.numbers.numbers import Numbers
+from sinch.domains.numbers.virtual_numbers import VirtualNumbers
 
-__all__ = ['Numbers']
+__all__ = ['VirtualNumbers']

--- a/sinch/domains/numbers/virtual_numbers.py
+++ b/sinch/domains/numbers/virtual_numbers.py
@@ -15,7 +15,7 @@ from sinch.domains.numbers.models.v1.types import (
 from sinch.domains.numbers.webhooks.v1 import NumbersWebhooks
 
 
-class Numbers:
+class VirtualNumbers:
     """
     Synchronous version of the Numbers domain.
 


### PR DESCRIPTION
Rename class to avoid conflict with Python's numbers module