### PR TITLE
Fix Ruff E402 errors in sinch_events server example

### DIFF
--- a/examples/sinch_events/conversation_api/controller.py
+++ b/examples/sinch_events/conversation_api/controller.py
@@ -1,5 +1,5 @@
 from flask import request, Response
-from sinch_events.conversation_api.server_business_logic import handle_conversation_event
+from conversation_api.server_business_logic import handle_conversation_event
 
 
 class ConversationController:

--- a/examples/sinch_events/numbers_api/controller.py
+++ b/examples/sinch_events/numbers_api/controller.py
@@ -1,5 +1,5 @@
 from flask import request, Response
-from sinch_events.numbers_api.server_business_logic import handle_numbers_event
+from numbers_api.server_business_logic import handle_numbers_event
 
 
 class NumbersController:

--- a/examples/sinch_events/server.py
+++ b/examples/sinch_events/server.py
@@ -1,17 +1,10 @@
 import logging
-import sys
-from pathlib import Path
-
-# Add examples directory to Python path to allow importing sinch_events
-examples_dir = Path(__file__).resolve().parent.parent
-if str(examples_dir) not in sys.path:
-    sys.path.insert(0, str(examples_dir))
 
 from flask import Flask, request
-from sinch_events.numbers_api.controller import NumbersController
-from sinch_events.sms_api.controller import SmsController
-from sinch_events.conversation_api.controller import ConversationController
-from sinch_events.sinch_client_helper import get_sinch_client, load_config
+from numbers_api.controller import NumbersController
+from sms_api.controller import SmsController
+from conversation_api.controller import ConversationController
+from sinch_client_helper import get_sinch_client, load_config
 
 app = Flask(__name__)
 

--- a/examples/sinch_events/sms_api/controller.py
+++ b/examples/sinch_events/sms_api/controller.py
@@ -1,5 +1,5 @@
 from flask import request, Response
-from sinch_events.sms_api.server_business_logic import (
+from sms_api.server_business_logic import (
     handle_sms_event,
 )
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary
- remove the pre-import `sys.path` mutation from `examples/sinch_events/server.py` to satisfy Ruff `E402`
- preserve runnable example behavior by aligning imports across the Sinch Events example package to local module imports
- keep endpoint/controller wiring unchanged

## Validation
- `python3 -m ruff check .`
<!-- CURSOR_AGENT_PR_BODY_END -->

[Slack Thread](https://sinch.slack.com/archives/D0ATPTT4ZCK/p1777020931220189?thread_ts=1777020931.220189&cid=D0ATPTT4ZCK)

<div><a href="https://cursor.com/agents/bc-913d8e77-0f7f-4a72-aef7-59e51640d9cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-913d8e77-0f7f-4a72-aef7-59e51640d9cd"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

