### PR TITLE
dependency(core): update requests minimal version required

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,14 @@ All notable changes to the **Sinch Python SDK** are documented in this file.
 
 ---
 
+## v2.1.0 – 
+
+### SDK
+
+- **[dependency]** Set up minimum version for `requests` to `>=2.0.0` (#152).
+
+---
+
 ## v2.0.1 – 2026-06-02
 
 ### SMS

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ keywords = ["sinch", "sdk"]
 
 [tool.poetry.dependencies]
 python = ">=3.9"
-requests = "*"
+requests = ">=2.0.0"
 pydantic = ">=2.0.0"
 
 [build-system]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,7 +8,7 @@ behave
 ruff
 
 # HTTP Libraries
-requests
+requests>=2.0.0
 
 # Data Validation
 pydantic >= 2.0.0


### PR DESCRIPTION
Bumps the minimum required version of the `requests` dependency to `>=2.0.0`.

No breaking change for existing users.