### PR TITLE
DEVEXP-1426: remove not necessary github secrets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,18 +1,6 @@
 name: Test Python SDK
 on: [ push ]
 
-env:
-  AUTH_ORIGIN: ${{ secrets.AUTH_ORIGIN }}
-  CONVERSATION_ORIGIN: ${{ secrets.CONVERSATION_ORIGIN }}
-  DISABLE_SSL: ${{ secrets.DISABLE_SSL }}
-  KEY_ID: ${{ secrets.KEY_ID }}
-  KEY_SECRET: ${{ secrets.KEY_SECRET }}
-  NUMBERS_ORIGIN: ${{ secrets.NUMBERS_ORIGIN }}
-  PROJECT_ID: ${{ secrets.PROJECT_ID }}
-  SERVICE_PLAN_ID: ${{ secrets.SERVICE_PLAN_ID }}
-  SMS_ORIGIN: ${{ secrets.SMS_ORIGIN }}
-  TEMPLATES_ORIGIN: ${{ secrets.TEMPLATES_ORIGIN }}
-
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -73,7 +61,7 @@ jobs:
       uses: actions/checkout@v4
       with:
         repository: sinch/sinch-sdk-mockserver
-        token: ${{ secrets.PAT_CI }}
+        token: ${{ secrets.MOCKSERVER_REPO_PAT_CI }}
         fetch-depth: 0
         path: sinch-sdk-mockserver
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ All notable changes to the **Sinch Python SDK** are documented in this file.
 - **[refactor]** `HTTPTransport` now prepares and authenticates requests in `request()`, so the new `send_request(request_data)` receives an already-prepared `HttpRequest` and acts as a pure I/O primitive, simplifying subclassing (#156).
 - **[deprecation notice]** `HTTPTransport.send(endpoint)` is deprecated in favour of `send_request(request_data)`; the legacy method still works for backward compatibility, but will be removed in 3.0 (#156).
 - **[deprecation notice]** `TokenManagerBase.invalidate_expired_token()` and `handle_invalid_token()` (and the `TokenState.EXPIRED` value) are deprecated and will be removed in 3.0, as token renewal now goes through `refresh_auth_token()` (#156).
+- **[tech]** Removed unused GitHub environment secrets from CI workflow and simplified test fixtures to use hardcoded test values (#162).
 
 
 ### SMS

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -34,72 +34,21 @@ class TokenBasedPaginationRequest(BaseModel):
     page_token: str = None
 
 
-def configure_origin(
-    sinch_client,
-    numbers_origin,
-    conversation_origin,
-    auth_origin,
-    sms_origin
-):
-    if auth_origin:
-        sinch_client.configuration.auth_origin = auth_origin
-
-    if numbers_origin:
-        sinch_client.configuration.numbers_origin = numbers_origin
-
-    if conversation_origin:
-        sinch_client.configuration.conversation_origin = conversation_origin
-
-    if sms_origin:
-        sinch_client.configuration.sms_origin = sms_origin
-        sinch_client.configuration.sms_origin_with_service_plan_id = sms_origin
-
-    return sinch_client
-
-
 @pytest.fixture
 def key_id():
-    return os.getenv("KEY_ID")
-
+    return "test_key_id"
 
 @pytest.fixture
 def key_secret():
-    return os.getenv("KEY_SECRET")
-
+    return "test_key_secret"
 
 @pytest.fixture
 def project_id():
-    return os.getenv("PROJECT_ID")
-
-
-@pytest.fixture
-def numbers_origin():
-    return os.getenv("NUMBERS_ORIGIN")
-
-
-@pytest.fixture
-def conversation_origin():
-    return os.getenv("CONVERSATION_ORIGIN")
-
-
-@pytest.fixture
-def auth_origin():
-    return os.getenv("AUTH_ORIGIN")
-
-
-@pytest.fixture
-def sms_origin():
-    return os.getenv("SMS_ORIGIN")
-
-
-@pytest.fixture
-def disable_ssl():
-    return os.getenv("DISABLE_SSL")
-
+    return "test_project_id"
 
 @pytest.fixture
 def service_plan_id():
-    return os.getenv("SERVICE_PLAN_ID")
+    return "test_service_plan_id"
 
 @pytest.fixture
 def http_response():
@@ -155,29 +104,17 @@ def sms_pagination_request_data_with_page_and_page_size_none():
     return SMSBasePaginationRequest()
 
 
-
 @pytest.fixture
 def sinch_client_sync(
     key_id,
     key_secret,
-    numbers_origin,
-    conversation_origin,
-    auth_origin,
-    sms_origin,
     project_id
 ):
-    return configure_origin(
-        SinchClient(
+    return SinchClient(
             key_id=key_id,
             key_secret=key_secret,
             project_id=project_id
-        ),
-        numbers_origin,
-        conversation_origin,
-        auth_origin,
-        sms_origin
-    )
-
+        )
 
 @pytest.fixture
 def mock_sinch_client_numbers():


### PR DESCRIPTION
### Remove not used Github secrets

- Remove unnecessary GitHub environment secrets from CI workflow
- Simplify test fixtures to use hardcoded test values
- Eliminate external dependencies from unit test configuration